### PR TITLE
Use working and warning free pip commands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ There are some situations where you might want to get specific URL parts:
 
 Either install directly:
 
-`pip install -e git+git@github.com:RRMoelker/django-full-url.git#egg=full_url`
+`pip install -e git+https://github.com/RRMoelker/django-full-url.git#egg=django-full-url`
 
 Or add the following line to your requirements file:
 
-`-e git+git@github.com:RRMoelker/django-full-url.git#egg=full_url`
+`-e git+https://github.com/RRMoelker/django-full-url.git#egg=django_full_url`
 
 
 ## Usage


### PR DESCRIPTION
git+git is not a secure connection. And #egg=full-url doesn't match your setup.py config
